### PR TITLE
Allow for proper config options

### DIFF
--- a/example/template/post.js
+++ b/example/template/post.js
@@ -1,0 +1,12 @@
+const template =
+`---
+title: "<%= front_matter.title %>"
+description: "<%= front_matter.description %>"
+date: "<%= date %>"
+slug: "<%= slug %>"
+---
+
+<%= content %>
+`;
+
+export default template;

--- a/src/generate.js
+++ b/src/generate.js
@@ -1,17 +1,28 @@
-import { isString } from 'lodash';
+import { isObject, isString } from 'lodash';
 import savePost from './savePost';
+import template from './template/post.js';
 
-const defaultDir = './posts';
+const defaultOptions = {
+  dest: './posts',
+  template: template,
+};
 
-export const generate = (dir = defaultDir) => (posts = []) => {
-  if (!isString(dir)) return false;
+export const generate = (options = defaultOptions) => (posts = []) => {
+  if (!isObject(options)) return false;
+
+  const config = Object.assign({}, defaultOptions, options);
+  const dest = config.dest;
+  const template = config.template;
+
+  if (!isString(dest) || !isString(template)) return false;
+
   const saveQueue = [];
 
   posts.forEach(post => {
-    saveQueue.push(savePost(dir)(post));
+    saveQueue.push(savePost(options)(post));
   });
 
-  return Promise.all(saveQueue);
+  return Promise.all(saveQueue).catch(err => console.log(err));
 };
 
 export default generate;

--- a/src/generate.js
+++ b/src/generate.js
@@ -22,7 +22,11 @@ export const generate = (options = defaultOptions) => (posts = []) => {
     saveQueue.push(savePost(options)(post));
   });
 
-  return Promise.all(saveQueue).catch(err => console.log(err));
+  return (
+    Promise.all(saveQueue)
+      /* istanbul ignore next */
+      .catch(err => err)
+  );
 };
 
 export default generate;

--- a/src/generatePost.js
+++ b/src/generatePost.js
@@ -2,9 +2,9 @@ import { isString, template } from 'lodash';
 import defaultPostTemplate from './template/post';
 
 const generatePost = (postTemplate = defaultPostTemplate) => {
-  if (!isString(postTemplate)) return false;
-
   return data => {
+    if (!isString(postTemplate)) return false;
+
     return template(postTemplate)(data);
   };
 };

--- a/src/generatePost.js
+++ b/src/generatePost.js
@@ -1,8 +1,12 @@
-import { template } from 'lodash';
-import postTemplate from './template/post';
+import { isString, template } from 'lodash';
+import defaultPostTemplate from './template/post';
 
-const generatePost = data => {
-  return template(postTemplate)(data);
+const generatePost = (postTemplate = defaultPostTemplate) => {
+  if (!isString(postTemplate)) return false;
+
+  return data => {
+    return template(postTemplate)(data);
+  };
 };
 
 export default generatePost;

--- a/src/getPosts.js
+++ b/src/getPosts.js
@@ -7,27 +7,39 @@ const endpoints = {
 };
 
 const getPosts = params => {
-  if (!isObject(params)) return false;
-
-  const defaultParams = {
-    archived: false,
-    state: 'PUBLISHED',
-  };
-  const url = getEndpointUrl(
-    endpoints.hubspot,
-    Object.assign({}, defaultParams, params)
-  );
-
-  /* istanbul ignore next */
-  // Test exists for this return. However, it's reporting incomplete since the
-  // else condition is being skipped.
-  if (!url || !isString(url)) return false;
-
   /* istanbul ignore next */
   // Skipping the coverage test of node-fetch
   return new Promise((resolve, reject) => {
+    if (!isObject(params)) {
+      reject("Marq requires an object for it's options");
+    }
+    if (!params.hapikey || !params.content_group_id) {
+      reject("Hmm… Something's not right with your Hubspot credentials.");
+    }
+
+    const defaultParams = {
+      archived: false,
+      state: 'PUBLISHED',
+    };
+    const url = getEndpointUrl(
+      endpoints.hubspot,
+      Object.assign({}, defaultParams, params)
+    );
+
+    /* istanbul ignore next */
+    // Test exists for this return. However, it's reporting incomplete since the
+    // else condition is being skipped.
+    if (!url || !isString(url)) {
+      reject("Hmm… Something's not right with your Hubspot credentials.");
+    }
+
     fetch(url)
-      .then(res => res.json())
+      .then(res => {
+        if (res.status !== 200) {
+          reject("Hmm… Something's not right with your Hubspot credentials.");
+        }
+        return res.json();
+      })
       .then(results => resolve(results.objects))
       .catch(err => reject(err));
   });

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,6 @@ const defaultOptions = {};
 
 const marq = (options = defaultOptions) => {
   const config = remapOptions(options);
-  // Todo: Actually parse options into arguments for the functions below
   return new Promise((resolve, reject) => {
     getPosts(config.query)
       .then(posts => {
@@ -16,7 +15,7 @@ const marq = (options = defaultOptions) => {
         };
         generate(o)(posts)
           .then(r => {
-            console.log(`marq generated ${r.length} posts into ./posts`);
+            console.log(`marq generated ${r.length} posts into ${config.dest}`);
             return resolve(r);
           })
           .catch(err => {

--- a/src/index.js
+++ b/src/index.js
@@ -1,14 +1,31 @@
 import generate from './generate';
 import getPosts from './getPosts';
+import remapOptions from './utils/remapOptions';
 
 const defaultOptions = {};
 
 const marq = (options = defaultOptions) => {
+  const config = remapOptions(options);
   // Todo: Actually parse options into arguments for the functions below
-  getPosts(options).then(posts => {
-    generate()(posts).then(r =>
-      console.log(`marq generated ${r.length} posts into ./posts`)
-    );
+  return new Promise((resolve, reject) => {
+    getPosts(config.query)
+      .then(posts => {
+        const o = {
+          dest: config.dest,
+          template: config.template,
+        };
+        generate(o)(posts)
+          .then(r => {
+            console.log(`marq generated ${r.length} posts into ./posts`);
+            return resolve(r);
+          })
+          .catch(err => {
+            return reject(err);
+          });
+      })
+      .catch(err => {
+        return reject(err);
+      });
   });
 };
 

--- a/src/mapDataToProps.js
+++ b/src/mapDataToProps.js
@@ -7,7 +7,7 @@ const mapDataToProps = data => {
   if (!isValidPost(data)) return false;
 
   const publishDate = getDate(data.publish_date);
-  const slug = slugify(data.slug);
+  const slug = slugify(data.slug.replace('blog/', ''));
   const title = data.html_title;
   const description = data.meta_description;
 

--- a/src/mapDataToProps.js
+++ b/src/mapDataToProps.js
@@ -11,16 +11,21 @@ const mapDataToProps = data => {
   const title = data.html_title;
   const description = data.meta_description;
 
-  return {
+  const featuredImage = data.featured_image
+    ? {
+        src: data.featured_image,
+        alt: data.featured_image_alt_text,
+        height: data.featured_image_height,
+        width: data.featured_image_width,
+      }
+    : null;
+
+  const marqData = {
     id: data.id,
     date: publishDate,
-    author: {
-      id: data.author_user_id,
-      username: data.author_username,
-      name: data.author_name,
-    },
     content: data.post_body,
     fileName: getFileName(publishDate, slug),
+    featuredImage,
     title,
     description,
     slug,
@@ -29,6 +34,10 @@ const mapDataToProps = data => {
       description: sanitize(description),
     },
   };
+
+  data.marq = marqData;
+
+  return data;
 };
 
 export default mapDataToProps;

--- a/src/savePost.js
+++ b/src/savePost.js
@@ -23,7 +23,7 @@ const savePost = (options = defaultOptions) => post => {
 
   const props = mapDataToProps(post);
   const markdown = generatePost(template)(props);
-  const filePath = `${dest}/${props.fileName}`;
+  const filePath = `${dest}/${props.marq.fileName}`;
 
   return new Promise((resolve, reject) => {
     mkdir(dest, err => {

--- a/src/savePost.js
+++ b/src/savePost.js
@@ -12,20 +12,25 @@ const defaultOptions = {
 };
 
 const savePost = (options = defaultOptions) => post => {
-  if (!isObject(options)) return false;
-  if (!isValidPost(post)) return false;
-
-  const config = Object.assign({}, defaultOptions, options);
-  const dest = config.dest;
-  const template = config.template;
-
-  if (!isString(dest) || !isString(template)) return false;
-
-  const props = mapDataToProps(post);
-  const markdown = generatePost(template)(props);
-  const filePath = `${dest}/${props.marq.fileName}`;
-
   return new Promise((resolve, reject) => {
+    if (!isObject(options)) {
+      reject('marq: Options needs to be an object');
+    }
+    if (!isValidPost(post)) {
+      reject("marq: Hmm… This post doesn't appear to be correct.");
+    }
+
+    const config = Object.assign({}, defaultOptions, options);
+    const dest = config.dest;
+    const template = config.template;
+
+    if (!isString(dest) || !isString(template)) {
+      reject("marq: Hmm… Looks like something's up with the configuration.");
+    }
+
+    const props = mapDataToProps(post);
+    const markdown = generatePost(template)(props);
+    const filePath = `${dest}/${props.marq.fileName}`;
     mkdir(dest, err => {
       /* istanbul ignore next */
       // skipping testing for mkdir's promise reject

--- a/src/savePost.js
+++ b/src/savePost.js
@@ -1,22 +1,32 @@
 import fs from 'fs';
 import mkdir from 'mkdirp';
-import { isString } from 'lodash';
+import { isObject, isString } from 'lodash';
 import generatePost from './generatePost';
 import mapDataToProps from './mapDataToProps';
 import { isValidPost } from './utils';
+import template from './template/post.js';
 
-const defaultDir = './posts';
+const defaultOptions = {
+  dest: './posts',
+  template: template,
+};
 
-const savePost = (dir = defaultDir) => post => {
-  if (!isString(dir)) return false;
+const savePost = (options = defaultOptions) => post => {
+  if (!isObject(options)) return false;
   if (!isValidPost(post)) return false;
 
+  const config = Object.assign({}, defaultOptions, options);
+  const dest = config.dest;
+  const template = config.template;
+
+  if (!isString(dest) || !isString(template)) return false;
+
   const props = mapDataToProps(post);
-  const markdown = generatePost(props);
-  const filePath = `${dir}/${props.fileName}`;
+  const markdown = generatePost(template)(props);
+  const filePath = `${dest}/${props.fileName}`;
 
   return new Promise((resolve, reject) => {
-    mkdir(dir, err => {
+    mkdir(dest, err => {
       /* istanbul ignore next */
       // skipping testing for mkdir's promise reject
       if (err) return reject(err);

--- a/src/template/post.js
+++ b/src/template/post.js
@@ -1,11 +1,11 @@
 const template = `---
-title: "<%= front_matter.title %>"
-description: "<%= front_matter.description %>"
-date: "<%= date %>"
-slug: "<%= slug %>"
+title: "<%= marq.front_matter.title %>"
+description: "<%= marq.front_matter.description %>"
+date: "<%= marq.date %>"
+slug: "<%= marq.slug %>"
 ---
 
-<%= content %>
+<%= marq.content %>
 `;
 
 export default template;

--- a/src/utils/remapOptions.js
+++ b/src/utils/remapOptions.js
@@ -1,0 +1,28 @@
+import { has, isObject } from 'lodash';
+import defaultTemplate from '../template/post';
+
+const remapOptions = (options = {}) => {
+  let output = {};
+  if (!isObject(options)) return output;
+  if (!has(options, 'hubspot')) return output;
+
+  const { hubspot, dest, template } = options;
+
+  const hapikey = hubspot.key;
+  const content_group_id = hubspot.blogId;
+
+  if (!hapikey || !content_group_id) return output;
+
+  output = {
+    query: {
+      hapikey,
+      content_group_id,
+    },
+    dest: dest ? dest : './_posts/',
+    template: template ? template : defaultTemplate,
+  };
+
+  return output;
+};
+
+export default remapOptions;

--- a/test/fixture/post.js
+++ b/test/fixture/post.js
@@ -7,7 +7,7 @@ const post = {
   author_user: 'Ms. Author',
   meta_description: 'This is so meta',
   post_body: '<strong>Super meta!</strong>',
-  slug: 'awesome-post!!!!!!',
+  slug: '/blog/awesome-post!!!!!!',
 };
 
 export default post;

--- a/test/generate.spec.js
+++ b/test/generate.spec.js
@@ -11,7 +11,13 @@ const options = {
 
 describe('generate', () => {
   it("should return false if dir argument isn't valid", () => {
+    const badOptions = {
+      dest: '',
+      template: 123,
+    };
+
     expect(generate(123)(posts)).to.be.false;
+    expect(generate(badOptions)(posts)).to.be.false;
   });
 
   it('should resolve promise if posts are valid', () => {
@@ -130,5 +136,12 @@ describe('generate', () => {
       .catch(err => {
         done(err);
       });
+  });
+
+  it('should error out if post is invalid', done => {
+    generate(options)([{ bad: true }]).then(err => {
+      expect(err).to.contain('marq');
+      done();
+    });
   });
 });

--- a/test/generate.spec.js
+++ b/test/generate.spec.js
@@ -27,9 +27,9 @@ describe('generate', () => {
         expect(post).to.exist;
         expect(post).to.be.a('string');
 
-        expect(post).to.contain(postProps.front_matter.title);
-        expect(post).to.contain(postProps.front_matter.description);
-        expect(post).to.contain(postProps.content);
+        expect(post).to.contain(postProps.marq.front_matter.title);
+        expect(post).to.contain(postProps.marq.front_matter.description);
+        expect(post).to.contain(postProps.marq.content);
 
         done();
       })
@@ -51,9 +51,9 @@ describe('generate', () => {
         expect(post).to.exist;
         expect(post).to.be.a('string');
 
-        expect(post).to.contain(postProps.front_matter.title);
-        expect(post).to.contain(postProps.front_matter.description);
-        expect(post).to.contain(postProps.content);
+        expect(post).to.contain(postProps.marq.front_matter.title);
+        expect(post).to.contain(postProps.marq.front_matter.description);
+        expect(post).to.contain(postProps.marq.content);
         expect(post).to.contain('custom');
 
         done();
@@ -87,9 +87,9 @@ describe('generate', () => {
         expect(post).to.exist;
         expect(post).to.be.a('string');
 
-        expect(post).to.contain(postProps.front_matter.title);
-        expect(post).to.contain(postProps.front_matter.description);
-        expect(post).to.contain(postProps.content);
+        expect(post).to.contain(postProps.marq.front_matter.title);
+        expect(post).to.contain(postProps.marq.front_matter.description);
+        expect(post).to.contain(postProps.marq.content);
 
         done();
       })
@@ -116,9 +116,9 @@ describe('generate', () => {
             expect(post).to.exist;
             expect(post).to.be.a('string');
 
-            expect(post).to.contain(postProps.front_matter.title);
-            expect(post).to.contain(postProps.front_matter.description);
-            expect(post).to.contain(postProps.content);
+            expect(post).to.contain(postProps.marq.front_matter.title);
+            expect(post).to.contain(postProps.marq.front_matter.description);
+            expect(post).to.contain(postProps.marq.content);
             expect(post).to.contain(newTitle);
 
             done();

--- a/test/generatePost.spec.js
+++ b/test/generatePost.spec.js
@@ -12,4 +12,11 @@ describe('generatePost', () => {
     expect(post).to.contain('slug: "awesome-post"');
     expect(post).to.contain(props.marq.content);
   });
+
+  it('should return false if template is invalid', () => {
+    const props = mapDataToProps(data);
+    const post = generatePost(1)(props);
+
+    expect(post).to.be.false;
+  });
 });

--- a/test/generatePost.spec.js
+++ b/test/generatePost.spec.js
@@ -5,7 +5,7 @@ import data from './fixture/post';
 describe('generatePost', () => {
   it('should output a Jekyll post (string) from data', () => {
     const props = mapDataToProps(data);
-    const post = generatePost(props);
+    const post = generatePost()(props);
 
     expect(post).to.contain('title: "HTML: Title"');
     expect(post).to.contain('date: "2016-12-16"');

--- a/test/generatePost.spec.js
+++ b/test/generatePost.spec.js
@@ -10,6 +10,6 @@ describe('generatePost', () => {
     expect(post).to.contain('title: "HTML: Title"');
     expect(post).to.contain('date: "2016-12-16"');
     expect(post).to.contain('slug: "awesome-post"');
-    expect(post).to.contain(props.content);
+    expect(post).to.contain(props.marq.content);
   });
 });

--- a/test/getPosts.spec.js
+++ b/test/getPosts.spec.js
@@ -1,11 +1,24 @@
 import getPosts from '../src/getPosts';
 
-describe('utils', () => {
-  describe('getPosts', () => {
-    it('should return false if params is invalid', () => {
-      expect(getPosts()).to.be.false;
-      expect(getPosts(123)).to.be.false;
-      expect(getPosts('id=123')).to.be.false;
-    });
+// Demo keys
+// https://developers.hubspot.com/docs/methods/blogv2/get_blog_posts
+const stubOptions = {
+  hapikey: 'demo',
+  content_group_id: '351076',
+};
+
+describe('getPosts', () => {
+  it('should return false if params is invalid', () => {
+    expect(getPosts()).to.be.rejected;
+    expect(getPosts(123)).to.be.rejected;
+    expect(getPosts('id=123')).to.be.rejected;
+  });
+
+  it('should fetch from Hubspot with correct options', () => {
+    expect(getPosts(stubOptions)).to.be.fulfilled;
+  });
+
+  it('should reject if options are incorrect', () => {
+    expect(getPosts({ fake: true })).to.be.rejected;
   });
 });

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -1,7 +1,7 @@
 import fs from 'fs';
 
 export const readPost = dir => post => {
-  const filePath = `${dir}/${post.fileName}`;
+  const filePath = `${dir}/${post.marq.fileName}`;
   return fs.readFileSync(filePath, { encoding: 'utf8' });
 };
 

--- a/test/mapDataToProps.spec.js
+++ b/test/mapDataToProps.spec.js
@@ -12,23 +12,20 @@ describe('mapDataToProps', () => {
   it('should transform HubSpot data to a marq structure', () => {
     const props = mapDataToProps(data);
 
-    expect(props.id).to.equal(data.id);
-    expect(props.title).to.equal(data.html_title);
-    expect(props.date).to.equal('2016-12-16');
-    expect(props.author.id).to.equal(data.author_user_id);
-    expect(props.author.username).to.equal(data.author_username);
-    expect(props.author.name).to.equal(data.author_name);
-    expect(props.description).to.equal(data.meta_description);
-    expect(props.content).to.equal(data.post_body);
-    expect(props.slug).to.equal('awesome-post');
-    expect(props.fileName).to.equal('2016-12-16-awesome-post.md');
+    expect(props.marq.id).to.equal(data.id);
+    expect(props.marq.title).to.equal(data.html_title);
+    expect(props.marq.date).to.equal('2016-12-16');
+    expect(props.marq.description).to.equal(data.meta_description);
+    expect(props.marq.content).to.equal(data.post_body);
+    expect(props.marq.slug).to.equal('awesome-post');
+    expect(props.marq.fileName).to.equal('2016-12-16-awesome-post.md');
   });
 
   it('should have front-matter sanitized content', () => {
     const props = mapDataToProps(data);
 
-    expect(props.front_matter).to.exist;
-    expect(props.front_matter.title).to.exist;
-    expect(props.front_matter.description).to.exist;
+    expect(props.marq.front_matter).to.exist;
+    expect(props.marq.front_matter.title).to.exist;
+    expect(props.marq.front_matter.description).to.exist;
   });
 });

--- a/test/mapDataToProps.spec.js
+++ b/test/mapDataToProps.spec.js
@@ -28,4 +28,23 @@ describe('mapDataToProps', () => {
     expect(props.marq.front_matter.title).to.exist;
     expect(props.marq.front_matter.description).to.exist;
   });
+
+  it('should provide featuredImage data if applicable', () => {
+    const newData = Object.assign({}, data, {
+      featured_image: 'yes.png',
+      featured_image_alt_text: 'yes',
+    });
+
+    const props = mapDataToProps(newData);
+
+    expect(props.marq.featuredImage).to.exist;
+    expect(props.marq.featuredImage.src).to.equal('yes.png');
+    expect(props.marq.featuredImage.alt).to.equal('yes');
+  });
+
+  it('should not provide featuredImage object if undefined', () => {
+    const props = mapDataToProps(data);
+
+    expect(props.marq.featuredImage).to.equal(null);
+  });
 });

--- a/test/savePost.spec.js
+++ b/test/savePost.spec.js
@@ -9,14 +9,22 @@ const options = {
 };
 
 describe('savePost', () => {
-  it("should return false if dir argument isn't valid", () => {
-    expect(savePost(123)(data)).to.be.false;
+  it("should be rejected if dir argument isn't valid", () => {
+    expect(savePost(123)(data)).to.be.rejected;
   });
 
-  it('should return false if post is invalid', () => {
-    expect(savePost(options)({})).to.be.false;
-    expect(savePost(options)()).to.be.false;
-    expect(savePost(options)('postttttttttt')).to.be.false;
+  it('should be rejected if post is invalid', () => {
+    expect(savePost(options)({})).to.be.rejected;
+    expect(savePost(options)()).to.be.rejected;
+    expect(savePost(options)('postttttttttt')).to.be.rejected;
+  });
+
+  it('should be rejected if options is invalid', () => {
+    const badOptions = {
+      dest: options.dest,
+      template: 123,
+    };
+    expect(savePost(badOptions)(data)).to.be.rejected;
   });
 
   it('should resolve promise if post is valid', () => {

--- a/test/savePost.spec.js
+++ b/test/savePost.spec.js
@@ -3,7 +3,10 @@ import savePost from '../src/savePost';
 import mapDataToProps from '../src/mapDataToProps';
 import data from './fixture/post';
 
-const dir = './test-dir';
+const options = {
+  dest: './test-dir',
+  template: './template/post.js',
+};
 
 describe('savePost', () => {
   it("should return false if dir argument isn't valid", () => {
@@ -11,13 +14,13 @@ describe('savePost', () => {
   });
 
   it('should return false if post is invalid', () => {
-    expect(savePost(dir)({})).to.be.false;
-    expect(savePost(dir)()).to.be.false;
-    expect(savePost(dir)('postttttttttt')).to.be.false;
+    expect(savePost(options)({})).to.be.false;
+    expect(savePost(options)()).to.be.false;
+    expect(savePost(options)('postttttttttt')).to.be.false;
   });
 
   it('should resolve promise if post is valid', () => {
-    expect(savePost(dir)(data)).to.be.fulfilled;
+    expect(savePost(options)(data)).to.be.fulfilled;
   });
 
   it('should output .md file into default dir', done => {

--- a/test/savePost.spec.js
+++ b/test/savePost.spec.js
@@ -32,9 +32,9 @@ describe('savePost', () => {
         expect(post).to.exist;
         expect(post).to.be.a('string');
 
-        expect(post).to.contain(postProps.front_matter.title);
-        expect(post).to.contain(postProps.front_matter.description);
-        expect(post).to.contain(postProps.content);
+        expect(post).to.contain(postProps.marq.front_matter.title);
+        expect(post).to.contain(postProps.marq.front_matter.description);
+        expect(post).to.contain(postProps.marq.content);
 
         done();
       })

--- a/test/template/custom-post.js
+++ b/test/template/custom-post.js
@@ -1,0 +1,12 @@
+const template = `---
+title: "<%= front_matter.title %>"
+description: "<%= front_matter.description %>"
+date: "<%= date %>"
+slug: "<%= slug %>"
+custom: "yup"
+---
+
+<%= content %>
+`;
+
+export default template;

--- a/test/template/custom-post.js
+++ b/test/template/custom-post.js
@@ -1,12 +1,12 @@
 const template = `---
-title: "<%= front_matter.title %>"
-description: "<%= front_matter.description %>"
-date: "<%= date %>"
-slug: "<%= slug %>"
+title: "<%= marq.front_matter.title %>"
+description: "<%= marq.front_matter.description %>"
+date: "<%= marq.date %>"
+slug: "<%= marq.slug %>"
 custom: "yup"
 ---
 
-<%= content %>
+<%= marq.content %>
 `;
 
 export default template;

--- a/test/utils/remapOptions.spec.js
+++ b/test/utils/remapOptions.spec.js
@@ -1,0 +1,92 @@
+import remapOptions from '../../src/utils/remapOptions';
+
+describe('utils', () => {
+  describe('remapOptions', () => {
+    it('should return an empty object if invalid options', () => {
+      expect(remapOptions()).to.be.an('object').that.is.empty;
+      expect(remapOptions('123')).to.be.an('object').that.is.empty;
+      expect(remapOptions(123)).to.be.an('object').that.is.empty;
+      expect(remapOptions([{ key: '123' }])).to.be.an('object').that.is.empty;
+
+      const semiValidOptions = {
+        hubspot: {
+          key: '123',
+        },
+      };
+
+      expect(remapOptions(semiValidOptions)).to.be.an('object').that.is.empty;
+    });
+
+    it('should remap hubspot configs to query values', () => {
+      const options = {
+        hubspot: {
+          key: 'demo',
+          blogId: 'id',
+        },
+      };
+
+      const config = remapOptions(options);
+
+      expect(config.query.hapikey).to.equal(options.hubspot.key);
+      expect(config.query.content_group_id).to.equal(options.hubspot.blogId);
+    });
+
+    it('should remap dest value', () => {
+      const options = {
+        hubspot: {
+          key: 'demo',
+          blogId: 'id',
+        },
+        dest: 'src/_posts/',
+      };
+
+      const config = remapOptions(options);
+
+      expect(config.dest).to.equal(options.dest);
+    });
+
+    it('should have a default dest value', () => {
+      const options = {
+        hubspot: {
+          key: 'demo',
+          blogId: 'id',
+        },
+      };
+
+      const config = remapOptions(options);
+
+      expect(config.dest).to.exist;
+      expect(config.dest).to.equal('./_posts/');
+    });
+
+    it('should remap template value', () => {
+      const options = {
+        hubspot: {
+          key: 'demo',
+          blogId: 'id',
+        },
+        template: 'template.js',
+      };
+
+      const config = remapOptions(options);
+
+      expect(config.template).to.exist;
+      expect(config.template).to.equal(options.template);
+    });
+
+    it('should have a default template value', () => {
+      const options = {
+        hubspot: {
+          key: 'demo',
+          blogId: 'id',
+        },
+      };
+
+      const config = remapOptions(options);
+
+      expect(config.template).to.exist;
+      expect(config.template).to.contain('title');
+      expect(config.template).to.contain('front_matter');
+    });
+  });
+});


### PR DESCRIPTION
This update refactors the various methods to allow for the user to pass in configs for Marq to do it's thing. The various methods have also been setup with (smart-ish) defaults.