### PR TITLE
Add extra functions to options for additional control

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,5 @@
 {
-  "presets": ["es2015"],
+  "presets": ["es2015", "stage-1"],
   "plugins": [
     "add-module-exports"
   ],

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 # Todo
 
 * [x] Add Fetch method to hit Hubspot's API
-* [-] Provide the main marq method for usage
+* [x] Provide the main marq method for usage
 * [ ] Fix: slug/file name for `/blog/` prefix

--- a/demo.js
+++ b/demo.js
@@ -1,9 +1,9 @@
 import marq from './src/index';
 
 // DEEETZ!
-const hubspotDeets = {
-  hapikey: 'secretz',
-  content_group_id: 'moar_secretz',
+const config = {
+  key: 'secretz',
+  blogId: 'moar_secretz',
 };
 
 // DROP DA DEEETZ!

--- a/package-lock.json
+++ b/package-lock.json
@@ -180,6 +180,28 @@
         "trim-right": "1.0.1"
       }
     },
+    "babel-helper-bindify-decorators": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-bindify-decorators/-/babel-helper-bindify-decorators-6.24.1.tgz",
+      "integrity": "sha1-FMGeXxQte0fxmlJDHlKxzLxAozA=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0",
+        "babel-traverse": "6.25.0",
+        "babel-types": "6.25.0"
+      }
+    },
+    "babel-helper-builder-binary-assignment-operator-visitor": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
+      "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
+      "dev": true,
+      "requires": {
+        "babel-helper-explode-assignable-expression": "6.24.1",
+        "babel-runtime": "6.23.0",
+        "babel-types": "6.25.0"
+      }
+    },
     "babel-helper-call-delegate": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
@@ -202,6 +224,29 @@
         "babel-runtime": "6.23.0",
         "babel-types": "6.25.0",
         "lodash": "4.17.4"
+      }
+    },
+    "babel-helper-explode-assignable-expression": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
+      "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0",
+        "babel-traverse": "6.25.0",
+        "babel-types": "6.25.0"
+      }
+    },
+    "babel-helper-explode-class": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-explode-class/-/babel-helper-explode-class-6.24.1.tgz",
+      "integrity": "sha1-fcKjkQ3uAHBW4eMdZAztPVTqqes=",
+      "dev": true,
+      "requires": {
+        "babel-helper-bindify-decorators": "6.24.1",
+        "babel-runtime": "6.23.0",
+        "babel-traverse": "6.25.0",
+        "babel-types": "6.25.0"
       }
     },
     "babel-helper-function-name": {
@@ -258,6 +303,19 @@
         "lodash": "4.17.4"
       }
     },
+    "babel-helper-remap-async-to-generator": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
+      "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
+      "dev": true,
+      "requires": {
+        "babel-helper-function-name": "6.24.1",
+        "babel-runtime": "6.23.0",
+        "babel-template": "6.25.0",
+        "babel-traverse": "6.25.0",
+        "babel-types": "6.25.0"
+      }
+    },
     "babel-helper-replace-supers": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
@@ -304,6 +362,124 @@
       "dev": true,
       "requires": {
         "babel-runtime": "6.23.0"
+      }
+    },
+    "babel-plugin-syntax-async-functions": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
+      "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
+      "dev": true
+    },
+    "babel-plugin-syntax-async-generators": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-6.13.0.tgz",
+      "integrity": "sha1-a8lj67FuzLrmuStZbrfzXDQqi5o=",
+      "dev": true
+    },
+    "babel-plugin-syntax-class-constructor-call": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-constructor-call/-/babel-plugin-syntax-class-constructor-call-6.18.0.tgz",
+      "integrity": "sha1-nLnTn+Q8hgC+yBRkVt3L1OGnZBY=",
+      "dev": true
+    },
+    "babel-plugin-syntax-class-properties": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
+      "integrity": "sha1-1+sjt5oxf4VDlixQW4J8fWysJ94=",
+      "dev": true
+    },
+    "babel-plugin-syntax-decorators": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-decorators/-/babel-plugin-syntax-decorators-6.13.0.tgz",
+      "integrity": "sha1-MSVjtNvePMgGzuPkFszurd0RrAs=",
+      "dev": true
+    },
+    "babel-plugin-syntax-dynamic-import": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
+      "integrity": "sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo=",
+      "dev": true
+    },
+    "babel-plugin-syntax-exponentiation-operator": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
+      "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
+      "dev": true
+    },
+    "babel-plugin-syntax-export-extensions": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-export-extensions/-/babel-plugin-syntax-export-extensions-6.13.0.tgz",
+      "integrity": "sha1-cKFITw+QiaToStRLrDU8lbmxJyE=",
+      "dev": true
+    },
+    "babel-plugin-syntax-object-rest-spread": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+      "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
+      "dev": true
+    },
+    "babel-plugin-syntax-trailing-function-commas": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
+      "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=",
+      "dev": true
+    },
+    "babel-plugin-transform-async-generator-functions": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-generator-functions/-/babel-plugin-transform-async-generator-functions-6.24.1.tgz",
+      "integrity": "sha1-8FiQAUX9PpkHpt3yjaWfIVJYpds=",
+      "dev": true,
+      "requires": {
+        "babel-helper-remap-async-to-generator": "6.24.1",
+        "babel-plugin-syntax-async-generators": "6.13.0",
+        "babel-runtime": "6.23.0"
+      }
+    },
+    "babel-plugin-transform-async-to-generator": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
+      "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
+      "dev": true,
+      "requires": {
+        "babel-helper-remap-async-to-generator": "6.24.1",
+        "babel-plugin-syntax-async-functions": "6.13.0",
+        "babel-runtime": "6.23.0"
+      }
+    },
+    "babel-plugin-transform-class-constructor-call": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-class-constructor-call/-/babel-plugin-transform-class-constructor-call-6.24.1.tgz",
+      "integrity": "sha1-gNwoVQWsBn3LjWxl4vbxGrd2Xvk=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-class-constructor-call": "6.18.0",
+        "babel-runtime": "6.23.0",
+        "babel-template": "6.25.0"
+      }
+    },
+    "babel-plugin-transform-class-properties": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz",
+      "integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw=",
+      "dev": true,
+      "requires": {
+        "babel-helper-function-name": "6.24.1",
+        "babel-plugin-syntax-class-properties": "6.13.0",
+        "babel-runtime": "6.23.0",
+        "babel-template": "6.25.0"
+      }
+    },
+    "babel-plugin-transform-decorators": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-decorators/-/babel-plugin-transform-decorators-6.24.1.tgz",
+      "integrity": "sha1-eIAT2PjGtSIr33s0Q5Df13Vp4k0=",
+      "dev": true,
+      "requires": {
+        "babel-helper-explode-class": "6.24.1",
+        "babel-plugin-syntax-decorators": "6.13.0",
+        "babel-runtime": "6.23.0",
+        "babel-template": "6.25.0",
+        "babel-types": "6.25.0"
       }
     },
     "babel-plugin-transform-es2015-arrow-functions": {
@@ -540,6 +716,55 @@
         "regexpu-core": "2.0.0"
       }
     },
+    "babel-plugin-transform-exponentiation-operator": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
+      "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
+      "dev": true,
+      "requires": {
+        "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
+        "babel-plugin-syntax-exponentiation-operator": "6.13.0",
+        "babel-runtime": "6.23.0"
+      }
+    },
+    "babel-plugin-transform-export-extensions": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-export-extensions/-/babel-plugin-transform-export-extensions-6.22.0.tgz",
+      "integrity": "sha1-U3OLR+deghhYnuqUbLvTkQm75lM=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-export-extensions": "6.13.0",
+        "babel-runtime": "6.23.0"
+      }
+    },
+    "babel-plugin-transform-object-rest-spread": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
+      "integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-object-rest-spread": "6.13.0",
+        "babel-runtime": "6.26.0"
+      },
+      "dependencies": {
+        "babel-runtime": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+          "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+          "dev": true,
+          "requires": {
+            "core-js": "2.4.1",
+            "regenerator-runtime": "0.11.0"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
+          "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A==",
+          "dev": true
+        }
+      }
+    },
     "babel-plugin-transform-regenerator": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.24.1.tgz",
@@ -600,6 +825,42 @@
         "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
         "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
         "babel-plugin-transform-regenerator": "6.24.1"
+      }
+    },
+    "babel-preset-stage-1": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-preset-stage-1/-/babel-preset-stage-1-6.24.1.tgz",
+      "integrity": "sha1-dpLNfc1oSZB+auSgqFWJz7niv7A=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-transform-class-constructor-call": "6.24.1",
+        "babel-plugin-transform-export-extensions": "6.22.0",
+        "babel-preset-stage-2": "6.24.1"
+      }
+    },
+    "babel-preset-stage-2": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-preset-stage-2/-/babel-preset-stage-2-6.24.1.tgz",
+      "integrity": "sha1-2eKWD7PXEYfw5k7sYrwHdnIZvcE=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-dynamic-import": "6.18.0",
+        "babel-plugin-transform-class-properties": "6.24.1",
+        "babel-plugin-transform-decorators": "6.24.1",
+        "babel-preset-stage-3": "6.24.1"
+      }
+    },
+    "babel-preset-stage-3": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-preset-stage-3/-/babel-preset-stage-3-6.24.1.tgz",
+      "integrity": "sha1-g2raCp56f6N8sTj7kyb4eTSkg5U=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
+        "babel-plugin-transform-async-generator-functions": "6.24.1",
+        "babel-plugin-transform-async-to-generator": "6.24.1",
+        "babel-plugin-transform-exponentiation-operator": "6.24.1",
+        "babel-plugin-transform-object-rest-spread": "6.26.0"
       }
     },
     "babel-register": {
@@ -1890,14 +2151,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -1906,6 +2159,14 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "babel-core": "6.24.1",
     "babel-plugin-add-module-exports": "0.2.1",
     "babel-preset-es2015": "6.24.1",
+    "babel-preset-stage-1": "6.24.1",
     "chai": "4.0.2",
     "chai-as-promised": "7.1.1",
     "coveralls": "2.13.1",

--- a/src/generate.js
+++ b/src/generate.js
@@ -1,4 +1,4 @@
-import { isObject, isString } from 'lodash'
+import { isFunction, isObject, isString } from 'lodash'
 import savePost from './savePost'
 import template from './template/post.js'
 
@@ -16,7 +16,8 @@ export const generate = (options = defaultOptions, remapPostData) => (
   const dest = config.dest
   const template = config.template
 
-  if (!isString(dest) || !isString(template)) return false
+  if ((!isString(dest) && !isFunction(dest)) || !isString(template))
+    return false
 
   const saveQueue = []
 

--- a/src/getPosts.js
+++ b/src/getPosts.js
@@ -18,8 +18,7 @@ const getPosts = params => {
     }
 
     const defaultParams = {
-      archived: false,
-      state: 'PUBLISHED'
+      archived: false
     }
     const url = getEndpointUrl(
       endpoints.hubspot,

--- a/src/index.js
+++ b/src/index.js
@@ -1,14 +1,17 @@
+import { isPlainObject } from 'lodash'
 import generate from './generate'
 import getPosts from './getPosts'
 import remapOptions from './utils/remapOptions'
 
 const defaultOptions = {
   logWhenComplete: true,
-  beforeGenerate: posts => posts,
-  remapPostData: props => props
+  beforeGenerate: /* istanbul ignore next */ posts => posts,
+  remapPostData: /* istanbul ignore next */ props => props
 }
 
-const marq = (options = defaultOptions) => {
+const marq = (options) => {
+  if (!isPlainObject(options)) return false
+
   const config = Object.assign({}, defaultOptions, remapOptions(options))
   const {
     beforeGenerate,
@@ -20,6 +23,8 @@ const marq = (options = defaultOptions) => {
   } = config
 
   return new Promise((resolve, reject) => {
+    /* istanbul ignore next */
+    // Tested in isolation
     getPosts(query)
       .then(posts => {
         const postData = beforeGenerate(posts)
@@ -27,7 +32,9 @@ const marq = (options = defaultOptions) => {
         generate({ dest, template }, remapPostData)(postData)
           .then(r => {
             if (logWhenComplete) {
-              console.log(`marq generated ${r.length} posts into ${config.dest}`)
+              console.log(
+                `marq generated ${r.length} posts into ${config.dest}`
+              )
             }
             return resolve(r)
           })

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ const defaultOptions = {
   remapPostData: /* istanbul ignore next */ props => props
 }
 
-const marq = (options) => {
+const marq = options => {
   if (!isPlainObject(options)) return false
 
   const config = Object.assign({}, defaultOptions, remapOptions(options))

--- a/src/savePost.js
+++ b/src/savePost.js
@@ -24,9 +24,11 @@ const savePost = (options = defaultOptions) => (post, remapPostData) => {
     const dest = config.dest
     const template = config.template
 
-    if (!isString(dest) || !isString(template)) {
+    if ((!isString(dest) && !isFunction(dest)) || !isString(template)) {
       reject("marq: Hmm… Looks like something's up with the configuration.")
     }
+
+    const fileDest = isFunction(dest) ? dest() : dest
 
     let props = mapDataToProps(post)
     if (remapPostData && isFunction(remapPostData)) {
@@ -34,8 +36,8 @@ const savePost = (options = defaultOptions) => (post, remapPostData) => {
     }
 
     const markdown = generatePost(template)(props)
-    const filePath = `${dest}/${props.marq.fileName}`
-    mkdir(dest, err => {
+    const filePath = `${fileDest}/${props.marq.fileName}`
+    mkdir(fileDest, err => {
       /* istanbul ignore next */
       // skipping testing for mkdir's promise reject
       if (err) return reject(err)

--- a/src/utils/remapOptions.js
+++ b/src/utils/remapOptions.js
@@ -6,7 +6,7 @@ const remapOptions = (options = {}) => {
   if (!isObject(options)) return output
   if (!has(options, 'hubspot')) return output
 
-  const { hubspot, dest, template } = options
+  const { hubspot, dest, template, ...rest } = options
 
   const hapikey = hubspot.key
   const content_group_id = hubspot.blogId
@@ -22,7 +22,7 @@ const remapOptions = (options = {}) => {
     template: template ? template : defaultTemplate
   }
 
-  return output
+  return Object.assign({}, output, rest)
 }
 
 export default remapOptions

--- a/test/generate.spec.js
+++ b/test/generate.spec.js
@@ -10,7 +10,7 @@ const options = {
 }
 
 describe('generate', () => {
-  it("should return false if dir argument isn't valid", () => {
+  it('should return false if dir argument isn\'t valid', () => {
     const badOptions = {
       dest: '',
       template: 123
@@ -18,6 +18,19 @@ describe('generate', () => {
 
     expect(generate(123)(posts)).to.be.false
     expect(generate(badOptions)(posts)).to.be.false
+  })
+
+  it('should not resolve promise if options.dest is valid, but options.template is not', () => {
+    const badOptions = {
+      dest: () => './test-dir',
+      template: () => 123
+    }
+    expect(generate(badOptions)(posts)).to.be.false
+  })
+
+  it('should resolve promise if options.dest is valid', () => {
+    expect(generate({ dest: './test-dir' })(posts)).to.be.fulfilled
+    expect(generate({ dest: () => './test-dir' })(posts)).to.be.fulfilled
   })
 
   it('should resolve promise if posts are valid', () => {

--- a/test/generate.spec.js
+++ b/test/generate.spec.js
@@ -10,7 +10,7 @@ const options = {
 }
 
 describe('generate', () => {
-  it('should return false if dir argument isn\'t valid', () => {
+  it("should return false if dir argument isn't valid", () => {
     const badOptions = {
       dest: '',
       template: 123

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -4,10 +4,17 @@ import marq from '../src/index'
 // https://developers.hubspot.com/docs/methods/blogv2/get_blog_posts
 const stubQuery = {
   key: 'demo',
-  blogId: '351076',
+  blogId: '351076'
 }
 
 describe('marq', () => {
+  it('should return false if argument is invalid', () => {
+    expect(marq()).to.be.false
+    expect(marq(() => {})).to.be.false
+    expect(marq([])).to.be.false
+    expect(marq(true)).to.be.false
+  })
+
   it('should fetch from Hubspot with correct options', () => {
     const options = {
       hubspot: stubQuery,
@@ -21,7 +28,7 @@ describe('marq', () => {
     const options = {
       hubspot: stubQuery,
       logWhenComplete: false,
-      beforeGenerate: (posts) => {
+      beforeGenerate: posts => {
         stub = posts
         return posts
       }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,0 +1,33 @@
+import marq from '../src/index'
+
+// Demo keys
+// https://developers.hubspot.com/docs/methods/blogv2/get_blog_posts
+const stubQuery = {
+  key: 'demo',
+  blogId: '351076',
+}
+
+describe('marq', () => {
+  it('should fetch from Hubspot with correct options', () => {
+    const options = {
+      hubspot: stubQuery,
+      logWhenComplete: false
+    }
+    expect(marq(options)).to.be.fulfilled
+  })
+
+  it('should fire beforeGenerate', () => {
+    let stub = false
+    const options = {
+      hubspot: stubQuery,
+      logWhenComplete: false,
+      beforeGenerate: (posts) => {
+        stub = posts
+        return posts
+      }
+    }
+    marq(options)
+
+    expect(stub).to.not.be.an('array')
+  })
+})

--- a/test/savePost.spec.js
+++ b/test/savePost.spec.js
@@ -51,6 +51,30 @@ describe('savePost', () => {
       })
   })
 
+  it('should output .md file into dir, with a dest() function', done => {
+    const options = {
+      dest: () => './test-dir',
+      template: './template/post.js'
+    }
+    savePost(options)(data)
+      .then(() => {
+        const postProps = mapDataToProps(data)
+        const post = readPost('./posts')(postProps)
+
+        expect(post).to.exist
+        expect(post).to.be.a('string')
+
+        expect(post).to.contain(postProps.marq.front_matter.title)
+        expect(post).to.contain(postProps.marq.front_matter.description)
+        expect(post).to.contain(postProps.marq.content)
+
+        done()
+      })
+      .catch(err => {
+        done(err)
+      })
+  })
+
   it('should remap post data if callback fn is defined', () => {
     const remapPostData = data => {
       return Object.assign({}, data, {


### PR DESCRIPTION
## Add extra functions to options for additional control

This commit adds two new function callbacks to the options argument
that's passed into `marq`. It allows for additional control for
content can be adjusted/rendered.

```js
const options = {
  ...
  beforeGenerate: posts => { ... },
  remapPostData: props => { ... },
}

marq(options)
```