### PR TITLE
Pass post data to dest()

### DIFF
--- a/src/savePost.js
+++ b/src/savePost.js
@@ -28,15 +28,16 @@ const savePost = (options = defaultOptions) => (post, remapPostData) => {
       reject("marq: Hmm… Looks like something's up with the configuration.")
     }
 
-    const fileDest = isFunction(dest) ? dest() : dest
 
     let props = mapDataToProps(post)
     if (remapPostData && isFunction(remapPostData)) {
       props = remapPostData(props)
     }
-
     const markdown = generatePost(template)(props)
+
+    const fileDest = isFunction(dest) ? dest(props) : dest
     const filePath = `${fileDest}/${props.marq.fileName}`
+
     mkdir(fileDest, err => {
       /* istanbul ignore next */
       // skipping testing for mkdir's promise reject


### PR DESCRIPTION
## Pass post data to dest()

This commit passes a single post data into the dest() callback.
This allows you to adjust the dest directory based on the post.