### PR TITLE
isValidPost: Remove post.body validation

### DIFF
--- a/src/utils/isValidPost.js
+++ b/src/utils/isValidPost.js
@@ -1,13 +1,12 @@
 import { isObject, isNumber, isString } from 'lodash'
 
 const isValidPost = (post = {}) => {
-  const { html_title, meta_description, post_body, publish_date, slug } = post
+  const { html_title, meta_description, publish_date, slug } = post
 
   return (
     isObject(post) &&
     isString(html_title) &&
     isString(meta_description) &&
-    isString(post_body) &&
     isNumber(publish_date) &&
     isString(slug)
   )


### PR DESCRIPTION
## isValidPost: Remove post.body validation

This update adjusts the `isValidPost` to allow for empty `post.body` content.
This allows for better flexibility on the consumer's end to handle posts
without content.

Recommended by @jaredmcdaniel 