### PR TITLE
Slugify: Fix slug handling

### DIFF
--- a/src/utils/slugify.js
+++ b/src/utils/slugify.js
@@ -3,7 +3,8 @@ const slugify = slug => {
     .toString()
     .toLowerCase()
     .replace(/\s+/g, '-') // Replace spaces with -
-    .replace(/[^\w\-]+/g, '') // Remove all non-word chars
+    .replace(/[^\w\-\/]+/g, '') // Remove all non-word chars
+    .replace(/\//g, '-') // Replace all slashes with -
     .replace(/\-\-+/g, '-') // Replace multiple - with single -
     .replace(/^-+/, '') // Trim - from start of text
     .replace(/-+$/, '') // Trim - from end of text

--- a/test/utils/getFileName.spec.js
+++ b/test/utils/getFileName.spec.js
@@ -11,4 +11,10 @@ describe('getFileName', () => {
 
     expect(fileName).to.equal('2011-01-01-hello.md')
   })
+
+  it('should correctly handle slugs with multiple slashes', () => {
+    const fileName = getFileName('2011-01-01', '/blog/category/year/month/day/post-name/page-2')
+
+    expect(fileName).to.equal('2011-01-01-category-year-month-day-post-name-page-2.md')
+  })
 })

--- a/test/utils/slugify.spec.js
+++ b/test/utils/slugify.spec.js
@@ -37,5 +37,11 @@ describe('utils', () => {
 
       expect(o).to.equal('hello-there')
     })
+
+    it('should replace slashes with hyphens', () => {
+      const o = slugify('/hello/there//friend//')
+
+      expect(o).to.equal('hello-there-friend')
+    })
   })
 })


### PR DESCRIPTION
## Slugify: Fix slug handling

This update fixes the `slugify` util function to better handle slashes. Previously, it would strip all slashes. Now, it correctly replaces slashes with `-`.

### Example

`/category/name/page-2` because `category-name-page-2`